### PR TITLE
Add PIL to process xlsx files containing images

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,2 @@
 openpyxl
+PIL


### PR DESCRIPTION
Currently importing this fails:

https://github.com/hmcts/Probate-CCD-Import-Spreadsheets/blob/master/spreadsheet/CCD_Probate_V21.02-Dev.xlsx

as it contains images. This should fix it.