### PR TITLE
Change mv to cp (for baked in definitions)

### DIFF
--- a/scripts/upload-definition.sh
+++ b/scripts/upload-definition.sh
@@ -21,7 +21,7 @@ if [ "_${CCD_DEF_URLS}" != "_" ]; then
       echo "done"
   done
 elif [ "_${CCD_DEF_FILENAME}" != "_" ]; then
-  mv /${CCD_DEF_FILENAME} /definitions/${CCD_DEF_FILENAME}
+  cp /${CCD_DEF_FILENAME} /definitions/${CCD_DEF_FILENAME}
 fi
 
 [ -z "$(ls -A /definitions)" ] && echo "No definitions found to download. Script terminated." && exit 22


### PR DESCRIPTION

### Change description ###

Change `mv` to `cp`. Permissions denied error when baking in definitions and using this image as a base: e.g. https://github.com/hmcts/cmc-ccd-definitions/blob/master/Dockerfile

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
